### PR TITLE
chore: update provider version requirements

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -9,7 +9,7 @@ env:
   AWS_SECRET_KEY: ${{ secrets.TERRATEST_AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ secrets.TERRATEST_AWS_REGION }}
   AWS_REGION: ${{ secrets.TERRATEST_AWS_REGION }}
-  WEBHOOK_URL: ${{ secrets.PAGER_DUTY_TEST_CLOUDWATCH_URL }}
+  PAGERDUTY_TOKEN: ${{ secrets.PAGERDUTY_TOKEN }}
 jobs:
   terratest:
     name: terratest

--- a/ec2-static-alarms/providers.tf
+++ b/ec2-static-alarms/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.52"
+      version = ">= 4.12"
     }
   }
 }

--- a/ec2-static-alarms/sns.tf
+++ b/ec2-static-alarms/sns.tf
@@ -8,9 +8,9 @@ resource "aws_sns_topic" "notifications" {
 }
 
 resource "aws_sns_topic_subscription" "subscription" {
-  for_each               = toset(var.https_webhooks)
+  count                  = length(var.https_webhooks)
   topic_arn              = aws_sns_topic.notifications.arn
   protocol               = "https"
-  endpoint               = each.value
+  endpoint               = var.https_webhooks[count.index]
   endpoint_auto_confirms = true
 }

--- a/ec2.tf
+++ b/ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200423"]
   }
 
   filter {

--- a/inputs.tf
+++ b/inputs.tf
@@ -1,9 +1,9 @@
-variable "https_webhooks" {
-  description = "Endpoint to send notifications of the alarms"
-  type        = list(string)
-}
-
 variable "aws_region" {
   description = "AWS Region where to run the tests"
+  type        = string
+}
+
+variable "pagerduty_token" {
+  description = "Token to initialize PagerDuty provider"
   type        = string
 }

--- a/pagerduty.tf
+++ b/pagerduty.tf
@@ -1,0 +1,36 @@
+resource "pagerduty_service" "test_service" {
+  name                    = "terratest-${random_string.test_instance.result}"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = 600
+  escalation_policy       = pagerduty_escalation_policy.test_escalation_policy.id
+  alert_creation          = "create_alerts_and_incidents"
+}
+
+resource "pagerduty_escalation_policy" "test_escalation_policy" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = pagerduty_user.test_user.id
+    }
+  }
+}
+
+resource "pagerduty_user" "test_user" {
+  name  = "Terratest User ${random_string.test_instance.result}"
+  email = "terratest-${random_string.test_instance.result}@honestbank.com"
+}
+
+data "pagerduty_vendor" "cloudwatch" {
+  name = "Cloudwatch"
+}
+
+resource "pagerduty_service_integration" "cloudwatch" {
+  name    = data.pagerduty_vendor.cloudwatch.name
+  service = pagerduty_service.test_service.id
+  vendor  = data.pagerduty_vendor.cloudwatch.id
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    pagerduty = {
+      source  = "pagerduty/pagerduty"
+      version = ">=2.4.1"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
   default_tags {
@@ -5,4 +14,8 @@ provider "aws" {
       Name = local.test_display_name
     }
   }
+}
+
+provider "pagerduty" {
+  token = var.pagerduty_token
 }

--- a/test.tf
+++ b/test.tf
@@ -2,7 +2,7 @@ module "alarms" {
   source           = "./ec2-static-alarms"
   sns_topic_name   = "terratest-ec2-static-alarms-${random_string.test_instance.result}_1"
   sns_display_name = "terratest EC2 static alarms ${random_string.test_instance.result}_1"
-  https_webhooks   = var.https_webhooks
+  https_webhooks   = [pagerduty_service_integration.cloudwatch.html_url]
   ec2_id           = aws_instance.test_ec2_1.id
   alarms = {
     "example-alarm" : {
@@ -13,6 +13,9 @@ module "alarms" {
       evaluation_period   = "1"
     }
   }
+  depends_on = [
+    time_sleep.wait_service_integration
+  ]
 }
 
 resource "random_string" "test_instance" {
@@ -26,3 +29,8 @@ locals {
   test_display_name = "terratest-ec2-static-alarms-${random_string.test_instance.result}"
 }
 
+resource "time_sleep" "wait_service_integration" {
+  depends_on = [pagerduty_service_integration.cloudwatch]
+
+  create_duration = "2m"
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require github.com/gruntwork-io/terratest v0.40.0
 
+require github.com/stretchr/testify v1.7.0
+
 require (
 	cloud.google.com/go v0.83.0 // indirect
 	cloud.google.com/go/storage v1.10.0 // indirect
@@ -52,7 +54,6 @@ require (
 	github.com/pquerna/otp v1.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tmccombs/hcl2json v0.3.3 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/urfave/cli v1.22.2 // indirect

--- a/test/subscribe_test.go
+++ b/test/subscribe_test.go
@@ -1,30 +1,22 @@
 package test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCanSubscribe(t *testing.T) {
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "..", ".")
-	awsRegion := getAwsRegion()
 
-	webhookURL := os.Getenv("WEBHOOK_URL")
-	require.NotEmpty(t, webhookURL, "WEBHOOK_URL environment variable must be set")
-
-	testInputs := map[string](interface{}){
-		"aws_region":     awsRegion,
-		"https_webhooks": []string{webhookURL},
+	testInputs, errorGettingTestInputs := getTestInputs()
+	if errorGettingTestInputs != nil {
+		t.Errorf("%s", errorGettingTestInputs.Error())
 	}
-
 	environmentVariables := map[string]string{}
-
 	initOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: testDir,
 		Vars:         testInputs,

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -15,4 +16,26 @@ func getAwsRegion() string {
 // Useful to stop here the debugger to inspect manually the created resources.
 func finalizeTest(t *testing.T, tfOptions *terraform.Options) {
 	terraform.Destroy(t, tfOptions)
+}
+
+func getPagerDutyToken() (string, error) {
+	pagerDutyToken := os.Getenv("PAGERDUTY_TOKEN")
+	if pagerDutyToken == "" {
+		return "", fmt.Errorf("PAGERDUTY_TOKEN is empty")
+	}
+	return pagerDutyToken, nil
+}
+
+func getTestInputs() (map[string](interface{}), error) {
+	awsRegion := getAwsRegion()
+
+	pagerDutyToken, errGettingPagerDutyToken := getPagerDutyToken()
+	if errGettingPagerDutyToken != nil {
+		return nil, errGettingPagerDutyToken
+	}
+	testInputs := map[string](interface{}){
+		"aws_region":      awsRegion,
+		"pagerduty_token": pagerDutyToken,
+	}
+	return testInputs, nil
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Relaxes the requirements on provider version, so that we can use this Terraform component without needing to instantiate a 3.x `hashicorp/aws` provider.
* Revamps the Terratest by making part of the Terratest to create PagerDuty test service to subscribe to AWS CloudWatch alarms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-cloudwatch/2)
<!-- Reviewable:end -->
